### PR TITLE
Add websocket server to update status page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 WEB3_PROVIDER=http://localhost:8545
 HTTP_PORT=80
+WS_PORT=8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 
 # Install app dependencies
 COPY package.json .
-RUN npm install
+RUN npm install --global
 
 # Copy app in
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: "node-etherview"
     ports:
      - "127.0.0.1:3000:3000"
+     - "127.0.0.1:3001:3001"
     volumes:
      - ./server.js:/usr/src/app/server.js
      - ./.env:/usr/src/app/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
      - "127.0.0.1:3000:3000"
      - "127.0.0.1:3001:3001"
     volumes:
-     - ./server.js:/usr/src/app/server.js
-     - ./.env:/usr/src/app/.env
-     - ./views:/usr/src/app/views
-     - ./routes:/usr/src/app/routes
-     - ./public:/usr/src/app/public
+     - .:/usr/src/app/
+    environment:
+     - NODE_PATH=/usr/local/lib/node_modules/node-etherview/node_modules/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "dotenv": "4.0.0",
         "express": "4.16.2",
+        "ws": "3.3.0",
         "web3": "0.14.0",
         "ejs": "2.5.7",
         "moment": "2.19.1"

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -12,4 +12,17 @@ $( document ).ready(function() {
             $(".showhideitem").removeClass("in");
         }
     });
+
+    // check if we have a wshost set
+    if ($("body").data('wshost') != '') {
+        // if so, setup the ws
+        var ws = new WebSocket($("body").data('wshost'));
+        // currently we're just listening for messages, and updating latest block on status page
+        ws.onmessage = function (event) {
+            var data = jQuery.parseJSON( event.data );
+            $(".latestBlockLink").attr('href', '/blocks/' + data.latestBlock);
+            $(".latestBlockLinkText").html( data.latestBlock );
+        };
+    }
+
 });

--- a/routes/status.js
+++ b/routes/status.js
@@ -19,7 +19,8 @@ router.get(['/', '/status'], (req, res) => {
             syncStats: web3.eth.syncing,
             latestBlock: web3.eth.blockNumber,
             accounts: web3.eth.accounts,
-            peerCount: web3.net.peerCount
+            peerCount: web3.net.peerCount,
+            wshost: 'ws://localhost:'+process.env.WS_PORT+'/'
         });
 })
 

--- a/server.js
+++ b/server.js
@@ -59,7 +59,7 @@ app.listen(process.env.HTTP_PORT, (err) => {
         return console.log('something bad happened', err)
     }
 
-    console.log(`server is listening on ${process.env.HTTP_PORT}`)
+    console.log(`webserver is listening on ${process.env.HTTP_PORT}`)
 })
 
 
@@ -76,7 +76,7 @@ wss.on('connection', function connection(ws, req) {
 });
 
 server.listen(process.env.WS_PORT, function listening() {
-    console.log('Listening on %d', server.address().port);
+    console.log('websocket server is listening on %d', server.address().port);
 });
 
 // periodically send latest block number to websocket clients

--- a/server.js
+++ b/server.js
@@ -6,11 +6,6 @@ require('dotenv').config()
 var express = require('express')
 var app = express()
 
-const WebSocket = require('ws');
-const http = require('http');
-const url = require('url');
-const Web3 = require('web3');
-
 app.set('view engine', 'ejs');
 
 // static files
@@ -62,28 +57,5 @@ app.listen(process.env.HTTP_PORT, (err) => {
     console.log(`webserver is listening on ${process.env.HTTP_PORT}`)
 })
 
-
-const server = http.createServer(app);
-const wss = new WebSocket.Server({ server });
-
-wss.on('connection', function connection(ws, req) {
-    const location = url.parse(req.url, true);
-
-    ws.on('message', function incoming(message) {
-        console.log('received: %s', message);
-    });
-
-});
-
-server.listen(process.env.WS_PORT, function listening() {
-    console.log('websocket server is listening on %d', server.address().port);
-});
-
-// periodically send latest block number to websocket clients
-const interval = setInterval(function newinfo() {
-    wss.clients.forEach(function each(ws) {
-        var web3 = new Web3(new Web3.providers.HttpProvider(process.env.WEB3_PROVIDER))
-
-        ws.send(JSON.stringify({'latestBlock': web3.eth.blockNumber}));
-    });
-  }, 3000);
+// load the websocket server
+var wss = require('./wsserver');

--- a/views/layouts/header.ejs
+++ b/views/layouts/header.ejs
@@ -17,7 +17,7 @@
 	<!-- JQuery -->
 	<script src="/js/app.js"></script>
 </head>
-<body>
+<body data-wshost="<%= typeof wshost!='undefined' ? wshost : '' %>">
 	<div class="container">
 		<nav style='padding:0 10px 10px;'>
 			<a href='/status'>Status</a>

--- a/views/pages/status.ejs
+++ b/views/pages/status.ejs
@@ -17,7 +17,7 @@
 		<% }); %>
 	</table>
 <% } else { %>
-	<div><a href="/blocks/<%= latestBlock %>">Latest block</a></div>
+	<div>Latest block: <a class='latestBlockLink' href="/blocks/<%= latestBlock %>"><span class='latestBlockLinkText'><%= latestBlock %></span></a></div>
 <% } %>
 <h3>PeerCount: <%= peerCount %></h3>
 

--- a/wsserver.js
+++ b/wsserver.js
@@ -1,0 +1,36 @@
+const WebSocket = require('ws');
+const http = require('http');
+const url = require('url');
+
+// load Web3 client, so we can talk to ethereum node
+const Web3 = require('web3');
+var web3 = new Web3(new Web3.providers.HttpProvider(process.env.WEB3_PROVIDER))
+
+var express = require('express')
+var app = express()
+
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+wss.on('connection', function connection(ws, req) {
+    const location = url.parse(req.url, true);
+
+    ws.on('message', function incoming(message) {
+        console.log('received: %s', message);
+    });
+
+});
+
+server.listen(process.env.WS_PORT, function listening() {
+    console.log('websocket server is listening on %d', server.address().port);
+});
+
+// periodically send latest block number to websocket clients
+const interval = setInterval(function newinfo() {
+    wss.clients.forEach(function each(ws) {
+
+        ws.send(JSON.stringify({'latestBlock': web3.eth.blockNumber}));
+    });
+  }, 3000);
+
+module.exports = wss


### PR DESCRIPTION
Websocket server runs alongside main webserver, and is used by the status page to push out updates to the latest block.